### PR TITLE
Skip addition of trivial constraints to canonical representation of the linear relation

### DIFF
--- a/src/linear_relation/canonical.rs
+++ b/src/linear_relation/canonical.rs
@@ -162,9 +162,7 @@ impl<G: PrimeGroup> CanonicalLinearRelation<G> {
             }
         }
 
-        // Only include constraints that are non-trivial (not zero constraints)
-        // QUESTION: Should this actually be done? In the 0 = [] case, this seems to be no loss. In
-        // the error case, this precludes including an always-false OR branch.
+        // Only include constraints that are non-trivial (not zero constraints).
         if rhs_terms.is_empty() {
             if canonical_image.is_identity().into() {
                 return Ok(());

--- a/src/linear_relation/canonical.rs
+++ b/src/linear_relation/canonical.rs
@@ -163,6 +163,8 @@ impl<G: PrimeGroup> CanonicalLinearRelation<G> {
         }
 
         // Only include constraints that are non-trivial (not zero constraints)
+        // QUESTION: Should this actually be done? In the 0 = [] case, this seems to be no loss. In
+        // the error case, this precludes including an always-false OR branch.
         if rhs_terms.is_empty() {
             if canonical_image.is_identity().into() {
                 return Ok(());

--- a/src/linear_relation/canonical.rs
+++ b/src/linear_relation/canonical.rs
@@ -170,7 +170,7 @@ impl<G: PrimeGroup> CanonicalLinearRelation<G> {
                 return Ok(());
             }
             return Err(InvalidInstance::new(
-                "constraint has empty right-hand side and non-identity left-hand side",
+                "trivially false constraint: constraint has empty right-hand side and non-identity left-hand side",
             ));
         }
 

--- a/src/linear_relation/canonical.rs
+++ b/src/linear_relation/canonical.rs
@@ -163,6 +163,15 @@ impl<G: PrimeGroup> CanonicalLinearRelation<G> {
         }
 
         // Only include constraints that are non-trivial (not zero constraints)
+        if rhs_terms.is_empty() {
+            if canonical_image.is_identity().into() {
+                return Ok(());
+            }
+            return Err(InvalidInstance::new(
+                "constraint has empty right-hand side and non-identity left-hand side",
+            ));
+        }
+
         self.image.push(canonical_image);
         self.linear_combinations.push(rhs_terms);
 

--- a/src/tests/test_validation_criteria.rs
+++ b/src/tests/test_validation_criteria.rs
@@ -133,7 +133,6 @@ mod instance_validation {
 
         // The following relation is trivially invalid.
         // That is, we know that no witness will ever satisfy it.
-        // In this case, we're letting the prover fail and build the relation anyways.
         let mut linear_relation = LinearRelation::<G>::new();
         let B_var = linear_relation.allocate_element();
         let C_var = linear_relation.allocate_eq(B_var);
@@ -146,7 +145,6 @@ mod instance_validation {
             .contains("trivially false constraint"));
 
         // Also in this case, we know that no witness will ever satisfy the relation.
-        // Also here, the relation is built even though the prover will never be able to give a valid proof for it.
         // X != B * pub_scalar + A * 3
         let mut linear_relation = LinearRelation::<G>::new();
         let [B_var, A_var] = linear_relation.allocate_elements();

--- a/src/tests/test_validation_criteria.rs
+++ b/src/tests/test_validation_criteria.rs
@@ -138,7 +138,12 @@ mod instance_validation {
         let B_var = linear_relation.allocate_element();
         let C_var = linear_relation.allocate_eq(B_var);
         linear_relation.set_elements([(B_var, B), (C_var, C)]);
-        assert!(linear_relation.canonical().is_ok());
+        assert!(linear_relation
+            .canonical()
+            .err()
+            .unwrap()
+            .message
+            .contains("trivially false constraint"));
 
         // Also in this case, we know that no witness will ever satisfy the relation.
         // Also here, the relation is built even though the prover will never be able to give a valid proof for it.
@@ -147,7 +152,12 @@ mod instance_validation {
         let [B_var, A_var] = linear_relation.allocate_elements();
         let X_var = linear_relation.allocate_eq(B_var * pub_scalar + A_var * Scalar::from(3));
         linear_relation.set_elements([(B_var, B), (A_var, A), (X_var, X)]);
-        assert!(linear_relation.canonical().is_ok());
+        assert!(linear_relation
+            .canonical()
+            .err()
+            .unwrap()
+            .message
+            .contains("trivially false constraint"));
 
         // The following relation is valid and should pass.
         let mut linear_relation = LinearRelation::<G>::new();


### PR DESCRIPTION
A comment implied that only non-trivial constraints should be added to the canonical linear relation. This PR implemts that, but I am unsure if we actually want to include this or not. I additionally had another question about the canonicalization of the linear relations, which I've added in a comment in this PR.
