### PR TITLE
chore: add Ian Goldberg to authors list in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0-sigma"
 authors = [
     "Nugzari Uzoevi <nougzarm@icloud.com>",
     "Michele Orrù <m@orru.net>",
+    "Ian Goldberg <iang@uwaterloo.ca>",
     "Lénaïck Gouriou <lg@leanear.io>"
 ]
 edition = "2021"


### PR DESCRIPTION
Ian does not have a github account but contributed heavily to the design and security of this package, including fixing many of my mistakes in constant time attempts, group definitions, validation criterias, and missing features.