### PR TITLE
Optimize small MSMs by using a naive implementation under size 16

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run benchmark test
+      # Run the msm benchmark, just to ensure it isn't broken.
+      run: cargo bench --bench msm -- --quick
 
   no-std-check:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,21 @@ ahash = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 bls12_381 = "0.8.0"
+criterion = { version = "0.7", features = ["html_reports"] }
 curve25519-dalek = { version = "4", default-features = false, features = ["serde", "rand_core", "alloc", "digest", "precomputed-tables", "group"] }
 hex = "0.4"
 hex-literal = "0.4"
 json = "0.12.4"
+k256 = { version = "0.13", features = ["arithmetic"] }
 libtest-mimic = "0.8.1"
+p256 = { version = "0.13", features = ["arithmetic"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.10"
+
+[[bench]]
+name = "msm"
+harness = false
 
 [profile.dev]
 # Makes tests run much faster at the cost of slightly longer builds and worse debug info.

--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -1,0 +1,72 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ff::Field;
+use group::Group;
+use rand::thread_rng;
+use sigma_proofs::VariableMultiScalarMul;
+
+fn bench_msm_curve25519_dalek(c: &mut Criterion) {
+    use curve25519_dalek::{RistrettoPoint, Scalar};
+
+    let mut group = c.benchmark_group("MSM curve25519-dalek RistrettoPoint");
+    let mut rng = thread_rng();
+
+    for size in [16, 64, 256, 1024].iter() {
+        let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
+        let bases: Vec<RistrettoPoint> = (0..*size)
+            .map(|_| RistrettoPoint::random(&mut rng))
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, _| {
+            b.iter(|| RistrettoPoint::msm(black_box(&scalars), black_box(&bases)))
+        });
+    }
+    group.finish();
+}
+
+fn bench_msm_k256(c: &mut Criterion) {
+    use k256::{ProjectivePoint, Scalar};
+
+    let mut group = c.benchmark_group("MSM k256 ProjectivePoint");
+    let mut rng = thread_rng();
+
+    for size in [16, 64, 256, 1024].iter() {
+        let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
+        let bases: Vec<ProjectivePoint> = (0..*size)
+            .map(|_| ProjectivePoint::random(&mut rng))
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, _| {
+            b.iter(|| ProjectivePoint::msm(black_box(&scalars), black_box(&bases)))
+        });
+    }
+    group.finish();
+}
+
+fn bench_msm_p256(c: &mut Criterion) {
+    use p256::{ProjectivePoint, Scalar};
+
+    let mut group = c.benchmark_group("MSM p256 ProjectivePoint");
+    let mut rng = thread_rng();
+
+    for size in [16, 64, 256, 1024].iter() {
+        let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
+        let bases: Vec<ProjectivePoint> = (0..*size)
+            .map(|_| ProjectivePoint::random(&mut rng))
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, _| {
+            b.iter(|| ProjectivePoint::msm(black_box(&scalars), black_box(&bases)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_msm_curve25519_dalek,
+    bench_msm_k256,
+    bench_msm_p256
+);
+criterion_main!(benches);

--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -63,10 +63,46 @@ fn bench_msm_p256(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_msm_bls12_381_g1(c: &mut Criterion) {
+    use bls12_381::{G1Projective, Scalar};
+
+    let mut group = c.benchmark_group("MSM bls12_381 G1Projective");
+    let mut rng = thread_rng();
+
+    for size in [1, 2, 4, 8, 16, 64, 256, 1024].iter() {
+        let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
+        let bases: Vec<G1Projective> = (0..*size).map(|_| G1Projective::random(&mut rng)).collect();
+
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, _| {
+            b.iter(|| G1Projective::msm(black_box(&scalars), black_box(&bases)))
+        });
+    }
+    group.finish();
+}
+
+fn bench_msm_bls12_381_g2(c: &mut Criterion) {
+    use bls12_381::{G2Projective, Scalar};
+
+    let mut group = c.benchmark_group("MSM bls12_381 G2Projective");
+    let mut rng = thread_rng();
+
+    for size in [1, 2, 4, 8, 16, 64, 256, 1024].iter() {
+        let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
+        let bases: Vec<G2Projective> = (0..*size).map(|_| G2Projective::random(&mut rng)).collect();
+
+        group.bench_with_input(BenchmarkId::new("size", size), size, |b, _| {
+            b.iter(|| G2Projective::msm(black_box(&scalars), black_box(&bases)))
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_msm_curve25519_dalek,
     bench_msm_k256,
-    bench_msm_p256
+    bench_msm_p256,
+    bench_msm_bls12_381_g1,
+    bench_msm_bls12_381_g2,
 );
 criterion_main!(benches);

--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -12,7 +12,7 @@ fn bench_msm_curve25519_dalek(c: &mut Criterion) {
     let mut group = c.benchmark_group("MSM curve25519-dalek RistrettoPoint");
     let mut rng = thread_rng();
 
-    for size in [16, 64, 256, 1024].iter() {
+    for size in [1, 2, 4, 8, 16, 64, 256, 1024].iter() {
         let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
         let bases: Vec<RistrettoPoint> = (0..*size)
             .map(|_| RistrettoPoint::random(&mut rng))
@@ -31,7 +31,7 @@ fn bench_msm_k256(c: &mut Criterion) {
     let mut group = c.benchmark_group("MSM k256 ProjectivePoint");
     let mut rng = thread_rng();
 
-    for size in [16, 64, 256, 1024].iter() {
+    for size in [1, 2, 4, 8, 16, 64, 256, 1024].iter() {
         let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
         let bases: Vec<ProjectivePoint> = (0..*size)
             .map(|_| ProjectivePoint::random(&mut rng))
@@ -50,7 +50,7 @@ fn bench_msm_p256(c: &mut Criterion) {
     let mut group = c.benchmark_group("MSM p256 ProjectivePoint");
     let mut rng = thread_rng();
 
-    for size in [16, 64, 256, 1024].iter() {
+    for size in [1, 2, 4, 8, 16, 64, 256, 1024].iter() {
         let scalars: Vec<Scalar> = (0..*size).map(|_| Scalar::random(&mut rng)).collect();
         let bases: Vec<ProjectivePoint> = (0..*size)
             .map(|_| ProjectivePoint::random(&mut rng))

--- a/src/group/msm.rs
+++ b/src/group/msm.rs
@@ -66,7 +66,6 @@ impl<G: PrimeGroup> VariableMultiScalarMul for G {
 
         // NOTE: Based on the msm benchmark in this repo, msm_pippenger provides improvements over
         // msm_naive past a small constant size, but is significantly slower for very small MSMs.
-        // TODO: Support specialized MSM selection based on the group.
         match scalars.len() {
             0 => Self::identity(),
             1..16 => msm_naive(bases, scalars),

--- a/src/group/msm.rs
+++ b/src/group/msm.rs
@@ -76,7 +76,7 @@ impl<G: PrimeGroup> VariableMultiScalarMul for G {
 
 /// A naive MSM implementation.
 fn msm_naive<G: PrimeGroup>(bases: &[G], scalars: &[G::Scalar]) -> G {
-    std::iter::zip(bases, scalars).map(|(g, x)| *g * x).sum()
+    core::iter::zip(bases, scalars).map(|(g, x)| *g * x).sum()
 }
 
 /// An MSM implementation that employ's Pippenger's algorithm and works for all groups that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) mod schnorr_protocol;
 pub mod tests;
 
 pub use fiat_shamir::Nizk;
+pub use group::msm::VariableMultiScalarMul;
 pub use linear_relation::LinearRelation;
 
 #[deprecated = "Use sigma_proofs::group::serialization instead"]


### PR DESCRIPTION
While looking into the performance of the OONI application, I realized that a naive MSM was producing better performance. It turns out that the naive MSM is better for small sizes, compared to the provided implementation of Pippenger's algorithm. This PR updates the MSM implementation to use a naive formula for inputs of size less than 16. 16 is chosen somewhat arbitrarily, by looking at the cross-over point in the (new) benchmark on my laptop.