### PR TITLE
api: Reinstaurates CryptoRngCore type in API.

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -23,6 +23,7 @@ use alloc::{vec, vec::Vec};
 use ff::{Field, PrimeField};
 use group::prime::PrimeGroup;
 use itertools::Itertools;
+use rand_core::CryptoRngCore;
 use sha3::{Digest, Sha3_256};
 use spongefish::{
     Decoding, Encoding, NargDeserialize, NargSerialize, VerificationError, VerificationResult,
@@ -840,7 +841,7 @@ where
     fn prover_commit_simple(
         protocol: &CanonicalLinearRelation<G>,
         witness: &<CanonicalLinearRelation<G> as SigmaProtocol>::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(ComposedCommitment<G>, ComposedProverState<G>), Error> {
         protocol.prover_commit(witness, rng).map(|(c, s)| {
             (
@@ -863,7 +864,7 @@ where
     fn prover_commit_and(
         protocols: &[ComposedRelation<G>],
         witnesses: &[ComposedWitness<G>],
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(ComposedCommitment<G>, ComposedProverState<G>), Error> {
         if protocols.len() != witnesses.len() {
             return Err(Error::InvalidInstanceWitnessPair);
@@ -912,7 +913,7 @@ where
     fn prover_commit_or(
         instances: &[ComposedRelation<G>],
         witnesses: &[ComposedWitness<G>],
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(ComposedCommitment<G>, ComposedProverState<G>), Error>
     where
         G: ConditionallySelectable,
@@ -1045,7 +1046,7 @@ where
         threshold: usize,
         instances: &[ComposedRelation<G>],
         witnesses: &[ComposedWitness<G>],
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(ComposedCommitment<G>, ComposedProverState<G>), Error>
     where
         G: ConditionallySelectable,
@@ -1224,7 +1225,7 @@ where
     fn prover_commit(
         &self,
         witness: &Self::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(Vec<Self::Commitment>, Self::ProverState), Error> {
         let (commitment, state) = match (self, witness) {
             (ComposedRelation::Simple(p), ComposedWitness::Simple(w)) => {
@@ -1526,7 +1527,7 @@ where
         Ok(vec![commitment])
     }
 
-    fn simulate_response(&self, rng: &mut impl ScalarRng) -> Vec<Self::Response> {
+    fn simulate_response(&self, rng: &mut impl CryptoRngCore) -> Vec<Self::Response> {
         let response = match self {
             ComposedRelation::Simple(p) => ComposedResponse::Simple(p.simulate_response(rng)),
             ComposedRelation::And(ps) => {
@@ -1541,7 +1542,7 @@ where
                 ComposedResponse::And(responses)
             }
             ComposedRelation::Or(ps) => {
-                let challenges = rng.random_scalars_vec::<G>(ps.len()).to_vec();
+                let challenges = G::random_scalars_vec(rng, ps.len());
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut r = p.simulate_response(&mut *rng);
@@ -1558,7 +1559,7 @@ where
                 }
 
                 let degree = ps.len() - *threshold;
-                let compressed_challenges = rng.random_scalars_vec::<G>(degree).to_vec();
+                let compressed_challenges = G::random_scalars_vec(rng, degree);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut r = p.simulate_response(&mut *rng);
@@ -1575,7 +1576,7 @@ where
 
     fn simulate_transcript(
         &self,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(Vec<Self::Commitment>, Self::Challenge, Vec<Self::Response>), Error> {
         match self {
             ComposedRelation::Simple(p) => {
@@ -1587,7 +1588,7 @@ where
                 ))
             }
             ComposedRelation::And(ps) => {
-                let [challenge] = rng.random_scalars::<G, _>();
+                let [challenge] = G::random_scalars(rng);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut resp = p.simulate_response(&mut *rng);
@@ -1619,7 +1620,7 @@ where
                 ))
             }
             ComposedRelation::Or(ps) => {
-                let challenges = rng.random_scalars_vec::<G>(ps.len() - 1);
+                let challenges = G::random_scalars_vec(rng, ps.len() - 1);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut resp = p.simulate_response(&mut *rng);
@@ -1656,7 +1657,7 @@ where
                 }
 
                 let degree = ps.len() - *threshold;
-                let compressed_challenges = rng.random_scalars_vec::<G>(degree);
+                let compressed_challenges = G::random_scalars_vec(rng, degree);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut resp = p.simulate_response(&mut *rng);
@@ -1667,7 +1668,7 @@ where
                     responses.push(response);
                 }
 
-                let [challenge] = rng.random_scalars::<G, _>();
+                let [challenge] = G::random_scalars(rng);
                 let full_challenges = expand_threshold_challenges(
                     *threshold,
                     ps.len(),

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1625,7 +1625,7 @@ where
                     .len()
                     .checked_sub(1)
                     .ok_or(Error::InvalidInstanceWitnessPair)?;
-                let challenges = rG::random_scalars_vec(rng, challenge_count);
+                let challenges = G::random_scalars_vec(rng, challenge_count);
                 let mut responses = Vec::with_capacity(ps.len());
                 for p in ps.iter() {
                     let mut resp = p.simulate_response(&mut *rng);

--- a/src/fiat_shamir.rs
+++ b/src/fiat_shamir.rs
@@ -11,10 +11,10 @@
 //! - `P`: the underlying Sigma protocol ([`SigmaProtocol`] trait).
 
 use crate::errors::Error;
-use crate::traits::ScalarRng;
 use crate::traits::SigmaProtocol;
 use crate::traits::SigmaProtocolSimulator;
 use alloc::vec::Vec;
+use rand_core::CryptoRngCore;
 use sha3::digest::{ExtendableOutput, Update, XofReader};
 use spongefish::{
     DomainSeparator, Encoding, NargDeserialize, NargSerialize, ProverState, VerifierState,
@@ -75,7 +75,7 @@ where
     pub fn prove_batchable(
         &self,
         witness: &P::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<Vec<u8>, Error> {
         let protocol_id = self.interactive_proof.protocol_identifier();
         let instance_label = self.interactive_proof.instance_label();
@@ -145,7 +145,7 @@ where
     pub fn prove_compact(
         &self,
         witness: &P::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<Vec<u8>, Error> {
         let protocol_id = self.interactive_proof.protocol_identifier();
         let instance_label = self.interactive_proof.instance_label();

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -3,19 +3,34 @@
 use alloc::vec::Vec;
 use core::{array::from_fn, iter::repeat_with};
 
-use group::{ff::Field, Group};
-use rand_core::{CryptoRng, RngCore};
+use group::Group;
+use rand_core::CryptoRngCore;
+use spongefish::Decoding;
 
 use crate::traits::ScalarRng;
 
-impl<R: RngCore + CryptoRng> ScalarRng for R {
-    fn random_scalars<G: Group, const N: usize>(&mut self) -> [G::Scalar; N] {
-        from_fn(|_| G::Scalar::random(&mut *self))
+/// Blanket implementation for all types that implement [`group::Group`] and
+/// its Scalar field implements [`spongefish::Decoding<u8>`].
+impl<G> ScalarRng for G
+where
+    G: Group,
+    G::Scalar: Decoding<[u8]>,
+{
+    fn random_scalars<const N: usize>(rng: &mut impl CryptoRngCore) -> [G::Scalar; N] {
+        from_fn(|_| sample_by_decoding(rng))
     }
 
-    fn random_scalars_vec<G: Group>(&mut self, n: usize) -> Vec<G::Scalar> {
+    fn random_scalars_vec(rng: &mut impl CryptoRngCore, n: usize) -> Vec<G::Scalar> {
         let mut v = Vec::with_capacity(n);
-        v.extend(repeat_with(|| G::Scalar::random(&mut *self)).take(n));
+        v.extend(repeat_with(|| sample_by_decoding::<G::Scalar>(rng)).take(n));
         v
     }
+}
+
+/// Returns a type by decoding a byte string sampled from a
+/// cryptographically-secure random source of bytes.
+fn sample_by_decoding<D: Decoding<[u8]>>(rng: &mut impl CryptoRngCore) -> D {
+    let mut repr = D::Repr::default();
+    rng.fill_bytes(repr.as_mut());
+    D::decode(repr)
 }

--- a/src/schnorr_protocol.rs
+++ b/src/schnorr_protocol.rs
@@ -12,6 +12,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 
 use group::prime::PrimeGroup;
+use rand_core::CryptoRngCore;
 use spongefish::{Decoding, Encoding, NargDeserialize, NargSerialize};
 
 fn protocol_identifier_for_group<G>() -> [u8; 64] {
@@ -69,13 +70,13 @@ where
     fn prover_commit(
         &self,
         witness: &Self::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(Vec<Self::Commitment>, Self::ProverState)> {
         if witness.len() != self.num_scalars {
             return Err(Error::InvalidInstanceWitnessPair);
         }
 
-        let nonces = rng.random_scalars_vec::<G>(self.num_scalars);
+        let nonces = G::random_scalars_vec(rng, self.num_scalars);
         let commitment = self.evaluate(&nonces);
         let prover_state = (nonces.to_vec(), witness.to_vec());
         Ok((commitment, prover_state))
@@ -272,8 +273,8 @@ where
     ///
     /// # Returns
     /// - A commitment and response forming a valid proof for the given challenge.
-    fn simulate_response(&self, rng: &mut impl ScalarRng) -> Vec<Self::Response> {
-        rng.random_scalars_vec::<G>(self.num_scalars)
+    fn simulate_response(&self, rng: &mut impl CryptoRngCore) -> Vec<Self::Response> {
+        G::random_scalars_vec(rng, self.num_scalars)
     }
 
     /// Simulates a full proof transcript using a randomly generated challenge.
@@ -283,8 +284,8 @@ where
     ///
     /// # Returns
     /// - A tuple `(commitment, challenge, response)` forming a valid proof.
-    fn simulate_transcript(&self, rng: &mut impl ScalarRng) -> Result<Transcript<Self>> {
-        let [challenge] = rng.random_scalars::<G, _>();
+    fn simulate_transcript(&self, rng: &mut impl CryptoRngCore) -> Result<Transcript<Self>> {
+        let [challenge] = G::random_scalars(rng);
         let response = self.simulate_response(rng);
         let commitment = self.simulate_commitment(&challenge, &response)?;
         Ok((commitment, challenge, response))

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,17 +7,21 @@
 use crate::errors::Result;
 use alloc::vec::Vec;
 use group::Group;
+use rand_core::CryptoRngCore;
 use spongefish::{Decoding, Encoding, NargDeserialize, NargSerialize};
 
-/// An automatic trait helper for sampling scalars from an RNG.
+/// An automatic trait helper for sampling group scalars from an RNG.
 ///
-/// This trait is implemented for all types implementing
-/// `rand_core::RngCore + rand_core::CryptoRng`.
+/// This trait is implemented for all types implementing [`group::Group`]
+/// and its Scalar field implements [`spongefish::Decoding`].
 /// Passing any cryptographically-secure random number generator (CSRNG) is
 /// recommended for creating proofs.
-pub trait ScalarRng {
-    fn random_scalars<G: Group, const N: usize>(&mut self) -> [G::Scalar; N];
-    fn random_scalars_vec<G: Group>(&mut self, n: usize) -> Vec<G::Scalar>;
+pub trait ScalarRng: Group
+where
+    <Self as Group>::Scalar: Decoding<[u8]>,
+{
+    fn random_scalars<const N: usize>(rng: &mut impl CryptoRngCore) -> [Self::Scalar; N];
+    fn random_scalars_vec(rng: &mut impl CryptoRngCore, n: usize) -> Vec<Self::Scalar>;
 }
 
 pub type Transcript<P> = (
@@ -73,7 +77,7 @@ pub trait SigmaProtocol {
     fn prover_commit(
         &self,
         witness: &Self::Witness,
-        rng: &mut impl ScalarRng,
+        rng: &mut impl CryptoRngCore,
     ) -> Result<(Vec<Self::Commitment>, Self::ProverState)>;
 
     /// Computes the prover's response to a challenge based on the prover state.
@@ -119,7 +123,7 @@ pub trait SigmaProtocolSimulator: SigmaProtocol {
     /// Generates a random response (e.g. for simulation or OR composition).
     ///
     /// Typically used to simulate a proof without a witness.
-    fn simulate_response(&self, rng: &mut impl ScalarRng) -> Vec<Self::Response>;
+    fn simulate_response(&self, rng: &mut impl CryptoRngCore) -> Vec<Self::Response>;
 
     /// Simulates a commitment for which ('commitment', 'challenge', 'response') is a valid transcript.
     ///
@@ -132,5 +136,5 @@ pub trait SigmaProtocolSimulator: SigmaProtocol {
 
     /// Generates a full simulated proof transcript (commitment, challenge, response)
     /// without requiring knowledge of a witness.
-    fn simulate_transcript(&self, rng: &mut impl ScalarRng) -> Result<Transcript<Self>>;
+    fn simulate_transcript(&self, rng: &mut impl CryptoRngCore) -> Result<Transcript<Self>>;
 }

--- a/tests/dudect.rs
+++ b/tests/dudect.rs
@@ -19,7 +19,6 @@
 
 mod relations;
 
-use core::{array::from_fn, iter::repeat_with};
 use std::{
     hint::black_box,
     sync::LazyLock,
@@ -27,9 +26,12 @@ use std::{
 };
 
 use curve25519_dalek::{RistrettoPoint as G, Scalar};
-use group::{ff::Field, Group};
 
 use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
+use rand_core::{
+    impls::{next_u32_via_fill, next_u64_via_fill},
+    CryptoRng, CryptoRngCore, Error, RngCore,
+};
 use serial_test::serial;
 use sigma_proofs::{
     composition::{ComposedRelation, ComposedWitness},
@@ -102,7 +104,7 @@ fn baseline() {
 }
 
 fn wide_relation<const WIDTH: usize>(
-    rng: &mut impl ScalarRng,
+    rng: &mut impl CryptoRngCore,
 ) -> (CanonicalLinearRelation<G>, Vec<Scalar>) {
     let mut rel = LinearRelation::<G>::new();
     let constraint: Sum<_> = (0..WIDTH)
@@ -110,7 +112,7 @@ fn wide_relation<const WIDTH: usize>(
         .sum();
     let _ = rel.allocate_eq(constraint);
 
-    let wit = rng.random_scalars::<G, WIDTH>();
+    let wit = G::random_scalars::<WIDTH>(rng);
     rel.compute_image(&wit).unwrap();
     (rel.try_into().unwrap(), wit.to_vec())
 }
@@ -169,13 +171,26 @@ where
 /// witnesses.
 struct FixedRng;
 
-impl ScalarRng for FixedRng {
-    fn random_scalars<G: Group, const N: usize>(&mut self) -> [G::Scalar; N] {
-        from_fn(|_| <G::Scalar as Field>::ONE)
+impl CryptoRng for FixedRng {}
+
+impl RngCore for FixedRng {
+    fn next_u32(&mut self) -> u32 {
+        next_u32_via_fill(self)
     }
 
-    fn random_scalars_vec<G: Group>(&mut self, n: usize) -> Vec<G::Scalar> {
-        repeat_with(|| <G::Scalar as Field>::ONE).take(n).collect()
+    fn next_u64(&mut self) -> u64 {
+        next_u64_via_fill(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        // Always returns ONE assuming the dest is interpreted as a big-endian number.
+        dest.fill(0);
+        dest[dest.len() - 1] = 0x01;
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Error> {
+        self.fill_bytes(dst);
+        Ok(())
     }
 }
 

--- a/tests/relations/mod.rs
+++ b/tests/relations/mod.rs
@@ -1,16 +1,22 @@
 use group::{ff::Field, prime::PrimeGroup, Group};
 
+use rand_core::CryptoRngCore;
 use sigma_proofs::{
     linear_relation::{CanonicalLinearRelation, LinearRelation, Sum},
     traits::ScalarRng,
     MultiScalarMul,
 };
+use spongefish::Decoding;
 
-pub(crate) fn random_elem<G: Group>(rng: &mut impl ScalarRng) -> G {
+pub(crate) fn random_elem<G>(rng: &mut impl CryptoRngCore) -> G
+where
+    G: Group,
+    G::Scalar: Decoding<[u8]>,
+{
     // Test helper only: this samples elements as x*G where x is known, so the discrete
     // logarithm of returned elements is known. Do not use this outside tests; it is insecure
     // for most concrete applications.
-    let [x] = rng.random_scalars::<G, _>();
+    let [x] = G::random_scalars(rng);
     G::generator() * x
 }
 
@@ -18,8 +24,12 @@ type Return<G> = (CanonicalLinearRelation<G>, Vec<<G as Group>::Scalar>);
 
 /// LinearMap for knowledge of a discrete logarithm relative to a fixed basepoint.
 #[allow(non_snake_case)]
-pub fn discrete_logarithm<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x] = rng.random_scalars::<G, _>();
+pub fn discrete_logarithm<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x] = G::random_scalars(rng);
     let mut relation = LinearRelation::new();
 
     let var_x = relation.allocate_scalar();
@@ -40,8 +50,12 @@ pub fn discrete_logarithm<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarR
 
 /// LinearMap for knowledge of a shifted discrete logarithm relative to a fixed basepoint.
 #[allow(non_snake_case)]
-pub fn shifted_dlog<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x] = rng.random_scalars::<G, _>();
+pub fn shifted_dlog<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x] = G::random_scalars(rng);
     let mut relation = LinearRelation::new();
 
     let var_x = relation.allocate_scalar();
@@ -61,8 +75,12 @@ pub fn shifted_dlog<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) ->
 
 /// LinearMap for knowledge of a discrete logarithm equality between two pairs.
 #[allow(non_snake_case)]
-pub fn dleq<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x] = rng.random_scalars::<G, _>();
+pub fn dleq<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x] = G::random_scalars(rng);
     let H = random_elem(rng);
     let mut relation = LinearRelation::new();
 
@@ -87,8 +105,12 @@ pub fn dleq<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<
 
 /// LinearMap for knowledge of a shifted dleq.
 #[allow(non_snake_case)]
-pub fn shifted_dleq<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x] = rng.random_scalars::<G, _>();
+pub fn shifted_dleq<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x] = G::random_scalars(rng);
     let H = random_elem(rng);
     let mut relation = LinearRelation::new();
 
@@ -113,8 +135,12 @@ pub fn shifted_dleq<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) ->
 
 /// LinearMap for knowledge of an opening to a Pedersen commitment.
 #[allow(non_snake_case)]
-pub fn pedersen_commitment<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x, r] = rng.random_scalars::<G, _>();
+pub fn pedersen_commitment<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x, r] = G::random_scalars(rng);
     let H = random_elem(rng);
     let mut relation = LinearRelation::new();
 
@@ -135,10 +161,12 @@ pub fn pedersen_commitment<G: PrimeGroup + MultiScalarMul>(rng: &mut impl Scalar
 }
 
 #[allow(non_snake_case)]
-pub fn twisted_pedersen_commitment<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
-    let [x, r] = rng.random_scalars::<G, _>();
+pub fn twisted_pedersen_commitment<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x, r] = G::random_scalars(rng);
     let H = random_elem(rng);
     let mut relation = LinearRelation::new();
 
@@ -160,11 +188,15 @@ pub fn twisted_pedersen_commitment<G: PrimeGroup + MultiScalarMul>(
 
 /// Test that a Pedersen commitment is in the given range.
 #[allow(non_snake_case)]
-pub fn range_instance_generation<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
+pub fn range_instance_generation<G>(
+    rng: &mut impl CryptoRngCore,
     input: u64,
     range: std::ops::Range<u64>,
-) -> Return<G> {
+) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let G = G::generator();
     let H = random_elem(rng);
 
@@ -203,7 +235,7 @@ pub fn range_instance_generation<G: PrimeGroup + MultiScalarMul>(
     );
 
     // Compute the witness
-    let [r] = rng.random_scalars::<G, _>();
+    let [r] = G::random_scalars(rng);
     let x = G::Scalar::from(input);
 
     // IMPORTANT: this segment of the witness generation is NOT constant-time.
@@ -229,7 +261,7 @@ pub fn range_instance_generation<G: PrimeGroup + MultiScalarMul>(
                 .sum::<G::Scalar>()
     );
     // set the randomness for the bit decomposition
-    let mut s = rng.random_scalars_vec::<G>(bases.len());
+    let mut s = G::random_scalars_vec(rng, bases.len());
     let partial_sum = (1..bases.len())
         .map(|i| G::Scalar::from(bases[i]) * s[i])
         .sum::<G::Scalar>();
@@ -256,22 +288,30 @@ pub fn range_instance_generation<G: PrimeGroup + MultiScalarMul>(
 
 /// Test that a Pedersen commitment is in `[0, bound)` for any `bound >= 0`.
 #[allow(non_snake_case)]
-pub fn test_range<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
+pub fn test_range<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     range_instance_generation(rng, 822, 0..1337)
 }
 
 /// LinearMap for knowledge of an opening for use in a BBS commitment.
 // BBS message length is 3
 #[allow(non_snake_case)]
-pub fn bbs_blind_commitment<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
+pub fn bbs_blind_commitment<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let [Q_2, J_1, J_2, J_3] = [
         random_elem(rng),
         random_elem(rng),
         random_elem(rng),
         random_elem(rng),
     ];
-    let [msg_1, msg_2, msg_3] = rng.random_scalars::<G, _>();
-    let [secret_prover_blind] = rng.random_scalars::<G, _>();
+    let [msg_1, msg_2, msg_3] = G::random_scalars(rng);
+    let [secret_prover_blind] = G::random_scalars(rng);
     let mut relation = LinearRelation::new();
 
     // these are computed before the proof in the specification
@@ -310,11 +350,13 @@ pub fn bbs_blind_commitment<G: PrimeGroup + MultiScalarMul>(rng: &mut impl Scala
 
 /// LinearMap for the user's specific relation: A * 1 + gen__disj1_x_r * B
 #[allow(non_snake_case)]
-pub fn weird_linear_combination<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
+pub fn weird_linear_combination<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let B = random_elem(rng);
-    let [gen__disj1_x_r] = rng.random_scalars::<G, _>();
+    let [gen__disj1_x_r] = G::random_scalars(rng);
     let mut sigma__lr = LinearRelation::new();
 
     let gen__disj1_x_r_var = sigma__lr.allocate_scalar();
@@ -339,8 +381,12 @@ pub fn weird_linear_combination<G: PrimeGroup + MultiScalarMul>(
 }
 
 #[allow(non_snake_case)]
-pub fn simple_subtractions<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
-    let [x] = rng.random_scalars::<G, _>();
+pub fn simple_subtractions<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
+    let [x] = G::random_scalars(rng);
     let B = random_elem(rng);
     let X = B * (x - G::Scalar::from(1));
 
@@ -357,11 +403,13 @@ pub fn simple_subtractions<G: PrimeGroup + MultiScalarMul>(rng: &mut impl Scalar
 }
 
 #[allow(non_snake_case)]
-pub fn subtractions_with_shift<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
+pub fn subtractions_with_shift<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let B = G::generator();
-    let [x] = rng.random_scalars::<G, _>();
+    let [x] = G::random_scalars(rng);
     let X = B * (x - G::Scalar::from(2));
 
     let mut linear_relation = LinearRelation::<G>::new();
@@ -377,15 +425,17 @@ pub fn subtractions_with_shift<G: PrimeGroup + MultiScalarMul>(
 }
 
 #[allow(non_snake_case)]
-pub fn cmz_wallet_spend_relation<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
+pub fn cmz_wallet_spend_relation<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     // Simulate the wallet spend relation from cmz
     let P_W = random_elem(rng);
     let A = random_elem(rng);
 
     // Secret values
-    let [n_balance, i_price, z_w_balance] = rng.random_scalars::<G, _>();
+    let [n_balance, i_price, z_w_balance] = G::random_scalars(rng);
     let fee = G::Scalar::from(5u64);
 
     // W.balance = N.balance + I.price + fee
@@ -421,9 +471,11 @@ pub fn cmz_wallet_spend_relation<G: PrimeGroup + MultiScalarMul>(
 }
 
 #[allow(non_snake_case)]
-pub fn nested_affine_relation<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
+pub fn nested_affine_relation<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let mut instance = LinearRelation::<G>::new();
     let var_r = instance.allocate_scalar();
     let var_A = instance.allocate_element();
@@ -434,7 +486,7 @@ pub fn nested_affine_relation<G: PrimeGroup + MultiScalarMul>(
 
     let A = random_elem(rng);
     let B = random_elem(rng);
-    let [r] = rng.random_scalars::<G, _>();
+    let [r] = G::random_scalars(rng);
     let C = A * G::Scalar::from(4) + B * (r * G::Scalar::from(2) + G::Scalar::from(3));
     instance.set_element(var_A, A);
     instance.set_element(var_B, B);
@@ -446,9 +498,11 @@ pub fn nested_affine_relation<G: PrimeGroup + MultiScalarMul>(
 }
 
 #[allow(non_snake_case)]
-pub fn pedersen_commitment_equality<G: PrimeGroup + MultiScalarMul>(
-    rng: &mut impl ScalarRng,
-) -> Return<G> {
+pub fn pedersen_commitment_equality<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let mut instance = LinearRelation::new();
 
     let [m, r1, r2] = instance.allocate_scalars();
@@ -460,14 +514,18 @@ pub fn pedersen_commitment_equality<G: PrimeGroup + MultiScalarMul>(
     instance.set_elements([(var_G, G::generator()), (var_H, random_elem(rng))]);
 
     let mut witness = vec![G::Scalar::from(42)];
-    witness.extend_from_slice(&rng.random_scalars::<G, 2>());
+    witness.extend_from_slice(&G::random_scalars::<2>(rng));
     instance.compute_image(&witness).unwrap();
 
     (instance.canonical().unwrap(), witness)
 }
 
 #[allow(non_snake_case)]
-pub fn elgamal_subtraction<G: PrimeGroup + MultiScalarMul>(rng: &mut impl ScalarRng) -> Return<G> {
+pub fn elgamal_subtraction<G>(rng: &mut impl CryptoRngCore) -> Return<G>
+where
+    G: PrimeGroup + MultiScalarMul,
+    G::Scalar: Decoding<[u8]>,
+{
     let mut instance = LinearRelation::new();
     let [dk, a, r] = instance.allocate_scalars();
     let [ek, C, D, H, G] = instance.allocate_elements();
@@ -481,11 +539,11 @@ pub fn elgamal_subtraction<G: PrimeGroup + MultiScalarMul>(rng: &mut impl Scalar
 
     let witness_dk = G::Scalar::from(4242);
     let witness_a = G::Scalar::from(1000);
-    let [witness_r] = rng.random_scalars::<G, _>();
+    let [witness_r] = G::random_scalars(rng);
     let witness = vec![witness_dk, witness_a, witness_r];
 
     // Assign group elements consistent with the witness so compute_image is unnecessary.
-    let [alt_gen_log] = rng.random_scalars::<G, _>();
+    let [alt_gen_log] = G::random_scalars(rng);
     let alt_gen = G::generator() * alt_gen_log;
     instance.set_elements([(G, G::generator()), (H, alt_gen)]);
     let ek_val = alt_gen * witness_dk;

--- a/tests/spec/rng.rs
+++ b/tests/spec/rng.rs
@@ -1,60 +1,16 @@
-use core::{array::from_fn, iter::repeat_with};
-
-use group::{ff::PrimeField, prime::PrimeGroup, Group};
+use rand_core::{
+    impls::{next_u32_via_fill, next_u64_via_fill},
+    CryptoRng, Error, RngCore,
+};
 use sha3::digest::{ExtendableOutput, Update, XofReader};
-use spongefish::Decoding;
 
-use sigma_proofs::traits::ScalarRng;
-
-pub struct MockScalarRng<I: Iterator<Item = Vec<u8>>>(pub I);
-
-impl<I: Iterator<Item = Vec<u8>>> MockScalarRng<I> {
-    fn next<G: Group>(&mut self) -> G::Scalar {
-        let scalar = self.0.next().expect("missing scalar bytes");
-        let mut repr = <G::Scalar as PrimeField>::Repr::default();
-        repr.as_mut().copy_from_slice(&scalar);
-        G::Scalar::from_repr(repr).expect("invalid scalar bytes")
-    }
-}
-
-impl<I: Iterator<Item = Vec<u8>>> ScalarRng for MockScalarRng<I> {
-    fn random_scalars<G: Group, const N: usize>(&mut self) -> [G::Scalar; N] {
-        from_fn(|_| self.next::<G>())
-    }
-
-    fn random_scalars_vec<G: Group>(&mut self, n: usize) -> Vec<G::Scalar> {
-        let mut v = Vec::with_capacity(n);
-        v.extend(repeat_with(|| self.next::<G>()).take(n));
-        v
-    }
-}
-
-pub fn proof_generation_rng<G>(count: usize) -> MockScalarRng<std::vec::IntoIter<Vec<u8>>>
-where
-    G: PrimeGroup,
-    G::Scalar: Decoding<[u8]>,
-{
-    MockScalarRng(test_drng_scalars::<G>(b"proof_generation_seed", count).into_iter())
-}
-
-fn test_drng_scalars<G>(seed_label: &[u8], count: usize) -> Vec<Vec<u8>>
-where
-    G: PrimeGroup,
-    G::Scalar: Decoding<[u8]>,
-{
-    let mut drng = TestDrng::from_seed(seed_label);
-    (0..count)
-        .map(|_| drng.random_scalar_bytes::<G>())
-        .collect()
-}
-
-struct TestDrng {
+pub struct TestDrng {
     state: sha3::Shake128,
     squeeze_offset: usize,
 }
 
 impl TestDrng {
-    fn from_seed(seed_label: &[u8]) -> Self {
+    pub fn from_seed(seed_label: &[u8]) -> Self {
         let mut initial_block = [0u8; 168];
         let domain = b"sigma-proofs/TestDRNG/SHAKE128";
         initial_block[..domain.len()].copy_from_slice(domain);
@@ -68,25 +24,12 @@ impl TestDrng {
         }
     }
 
-    fn random_scalar_bytes<G>(&mut self) -> Vec<u8>
-    where
-        G: PrimeGroup,
-        G::Scalar: Decoding<[u8]>,
-    {
-        let mut repr = <G::Scalar as Decoding<[u8]>>::Repr::default();
-        let uniform_bytes = self.squeeze(repr.as_mut().len());
-        repr.as_mut().copy_from_slice(&uniform_bytes);
-        let scalar = G::Scalar::decode(repr);
-        scalar.to_repr().as_ref().to_vec()
-    }
-
-    fn squeeze(&mut self, length: usize) -> Vec<u8> {
-        let end = self.squeeze_offset + length;
+    fn squeeze_into(&mut self, buf: &mut [u8]) {
+        let end = self.squeeze_offset + buf.len();
         let mut full = vec![0u8; end];
         self.state.clone().finalize_xof().read(&mut full);
-        let out = full[self.squeeze_offset..end].to_vec();
+        buf.copy_from_slice(&full[self.squeeze_offset..end]);
         self.squeeze_offset = end;
-        out
     }
 }
 
@@ -94,4 +37,25 @@ fn fixed_seed(label: &[u8]) -> [u8; 32] {
     let mut seed = [0u8; 32];
     seed[..label.len()].copy_from_slice(label);
     seed
+}
+
+impl CryptoRng for TestDrng {}
+
+impl RngCore for TestDrng {
+    fn next_u32(&mut self) -> u32 {
+        next_u32_via_fill(self)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        next_u64_via_fill(self)
+    }
+
+    fn fill_bytes(&mut self, dst: &mut [u8]) {
+        self.squeeze_into(dst)
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Error> {
+        self.fill_bytes(dst);
+        Ok(())
+    }
 }

--- a/tests/spec/rng.rs
+++ b/tests/spec/rng.rs
@@ -2,38 +2,32 @@ use rand_core::{
     impls::{next_u32_via_fill, next_u64_via_fill},
     CryptoRng, Error, RngCore,
 };
-use sha3::digest::{ExtendableOutput, Update, XofReader};
 
-pub struct TestDrng {
-    state: sha3::Shake128,
-    squeeze_offset: usize,
-}
+use spongefish::{instantiations::Shake128, DuplexSpongeInterface as _};
+
+/// TestDrng from draft-sigma specification [1].
+///
+/// [1] https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-sigma-protocols-02#appendix-A.1
+pub struct TestDrng(Shake128);
 
 impl TestDrng {
     pub fn from_seed(seed_label: &[u8]) -> Self {
+        const DOMAIN: &[u8] = b"sigma-proofs/TestDRNG/SHAKE128";
         let mut initial_block = [0u8; 168];
-        let domain = b"sigma-proofs/TestDRNG/SHAKE128";
-        initial_block[..domain.len()].copy_from_slice(domain);
+        initial_block[..DOMAIN.len()].copy_from_slice(DOMAIN);
 
-        let mut state = sha3::Shake128::default();
-        state.update(&initial_block);
-        state.update(&fixed_seed(seed_label));
-        Self {
-            state,
-            squeeze_offset: 0,
-        }
-    }
-
-    fn squeeze_into(&mut self, buf: &mut [u8]) {
-        let end = self.squeeze_offset + buf.len();
-        let mut full = vec![0u8; end];
-        self.state.clone().finalize_xof().read(&mut full);
-        buf.copy_from_slice(&full[self.squeeze_offset..end]);
-        self.squeeze_offset = end;
+        let mut sponge = Shake128::default();
+        sponge.absorb(&initial_block);
+        sponge.absorb(&fixed_seed(seed_label));
+        Self(sponge)
     }
 }
 
 fn fixed_seed(label: &[u8]) -> [u8; 32] {
+    if label.len() > 32 {
+        panic!("seed label length must be less or equal to 32 bytes")
+    }
+
     let mut seed = [0u8; 32];
     seed[..label.len()].copy_from_slice(label);
     seed
@@ -51,7 +45,7 @@ impl RngCore for TestDrng {
     }
 
     fn fill_bytes(&mut self, dst: &mut [u8]) {
-        self.squeeze_into(dst)
+        self.0.squeeze(dst);
     }
 
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Error> {

--- a/tests/spec_vectors.rs
+++ b/tests/spec_vectors.rs
@@ -6,7 +6,7 @@ use spongefish::{Decoding, Encoding, NargDeserialize, NargSerialize};
 use sigma_proofs::{linear_relation::CanonicalLinearRelation, MultiScalarMul, Nizk};
 
 mod spec;
-use spec::{rng::proof_generation_rng, vectors::TestVector};
+use spec::{rng::TestDrng, vectors::TestVector};
 
 #[test]
 fn test_spec_vectors_p256() {
@@ -75,7 +75,7 @@ where
             "compact proof from vectors did not verify for {test_name}"
         );
 
-        let mut proof_rng = proof_generation_rng::<G>(2 * witness.len());
+        let mut proof_rng = TestDrng::from_seed(b"proof_generation_seed");
         let batchable_proof = nizk.prove_batchable(&witness, &mut proof_rng).unwrap();
         assert_eq!(
             batchable_proof, vector.batchable_proof.0,


### PR DESCRIPTION
makes the API functoins to accept any type implementing CryptoRngCore for sampling scalars. 
The required functionality from `rng` is now implemented internally.
