### PR TITLE
chore(renovate): automerge green patch/pin/digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge low-risk updates once CI is green: patch releases, pins, digests",
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
Lets renovate merge its own low-risk PRs (patch releases, pins, digests, lockfile maintenance) once CI is green, ending the drip of trivial lockfile PRs (#204, #211 et al.). Majors and minors still require review.