### PR TITLE
chore(renovate): lift open-PR cap that starves patch automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "prConcurrentLimit": 0,
   "packageRules": [
     {
       "description": "Automerge low-risk updates once CI is green: patch releases, pins, digests",


### PR DESCRIPTION
Renovate has not opened a PR here since #213/#214. The ten open major/minor bumps fill its default `prConcurrentLimit` of 10, so the patch bumps and weekly lock-file maintenance that #212 made automergeable sit as "Rate-Limited" on the dashboard (#158) and nothing merges. spongefish has no parked PRs, which is why automerge works there.

`prConcurrentLimit: 0` removes the cap; the default 2-per-hour creation limit still applies, and majors and minors still wait for review.